### PR TITLE
[Update] PHP 7.4+ Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,27 @@
 This lightweight PHP library helps you decode and verify JSON Web Tokens easily.
 
 ```php
+use \musa11971\JWTDecoder\JWTDecoder;
+
+$jwt = 'JSON Web Token';
+$key = 'Key';
+
 $payload = JWTDecoder::token($jwt)
-                ->withKey($publicKey)
+                ->withKey($key)
                 ->decode();
 ```
 
 ## Installation
 
-You can install the library via composer:
+You can download a release and manually include it in your project:
+
+| PHP Version   | JWT Decoder Version   |
+| ------------- |-----------------------|
+| PHP 7.3       | [JWT Decoder 1.0](../../releases/tag/1.0)               |
+| PHP 7.4       | [JWT Decoder 2.0](../../releases/tag/2.0)               |
+| PHP 8.0       | [JWT Decoder 2.0](../../releases/tag/2.0)               |
+
+Alternatively you can install the library via composer:
 
 ```bash
 composer require musa11971/php-jwt-decoder
@@ -32,7 +45,13 @@ composer require musa11971/php-jwt-decoder
 
 ### Basic decoding
 Pass on your JWT and (public) key (e.g. PEM) as strings.
+
 ```php
+use musa11971\JWTDecoder\JWTDecoder;
+
+$jwt = 'JSON Web Token';
+$key = 'Key';
+
 $payload = JWTDecoder::token($jwt)
                 ->withKey($key)
                 ->decode();
@@ -41,7 +60,11 @@ $payload = JWTDecoder::token($jwt)
 ### Decoding with multiple keys
 You may have multiple potential keys, one of which is the correct one for the JWT. This library allows you to simply pass on all the keys, and it will try every key until the signature is verified.  
 Do note that if none of the keys are correct, you will be met with an exception.
+
 ```php
+use musa11971\JWTDecoder\JWTDecoder;
+
+$jwt = 'JSON Web Token';
 $keys = [...]; // Array of keys
 
 $payload = JWTDecoder::token($jwt)
@@ -50,8 +73,14 @@ $payload = JWTDecoder::token($jwt)
 ```
 
 ### Ignoring the token expiry time
-By default, the library will check the token's expiry time ([exp](https://tools.ietf.org/html/rfc7519#section-4.1.4)) if it is present. However, if (for whatever reason) you wish to ignore the expiry time, you can use the following option. 
+By default, the library will check the token's expiry time ([exp](https://tools.ietf.org/html/rfc7519#section-4.1.4)) if it is present. However, if (for whatever reason) you wish to ignore the expiry time, you can use the following option.
+
 ```php
+use musa11971\JWTDecoder\JWTDecoder;
+
+$jwt = 'JSON Web Token';
+$key = 'Key';
+
 $payload = JWTDecoder::token($jwt)
                 ->withKey($key)
                 ->ignoreExpiry()
@@ -60,7 +89,13 @@ $payload = JWTDecoder::token($jwt)
 
 ### Ignoring the token 'not valid before' time
 Similarly to the `ignoreExpiry` option, you can also ignore the 'not valid before' time of the token ([nbf](https://tools.ietf.org/html/rfc7519#section-4.1.5)).
+
 ```php
+use musa11971\JWTDecoder\JWTDecoder;
+
+$jwt = 'JSON Web Token';
+$key = 'Key';
+
 $payload = JWTDecoder::token($jwt)
                 ->withKey($key)
                 ->ignoreNotValidBefore()

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,14 @@
         }
     ],
     "require": {
-        "php": "^7.3"
+        "php": "^7.4|^8.0",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-openssl": "*"
     },
     "require-dev": {
-        "firebase/php-jwt": "^5.1",
-        "phpunit/phpunit": "^8.2"
+        "firebase/php-jwt": "^5.2",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exceptions/BeforeValidException.php
+++ b/src/Exceptions/BeforeValidException.php
@@ -6,6 +6,11 @@ use Exception;
 
 class BeforeValidException extends Exception
 {
+    /**
+     * BeforeValidException constructor.
+     *
+     * @param $message
+     */
     public function __construct($message)
     {
         parent::__construct($message);

--- a/src/Exceptions/ExpiredJWTException.php
+++ b/src/Exceptions/ExpiredJWTException.php
@@ -6,6 +6,11 @@ use Exception;
 
 class ExpiredJWTException extends Exception
 {
+    /**
+     * ExpiredJWTException constructor.
+     *
+     * @param $message
+     */
     public function __construct($message)
     {
         parent::__construct($message);

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -6,6 +6,11 @@ use Exception;
 
 class InvalidArgumentException extends Exception
 {
+    /**
+     * InvalidArgumentException constructor.
+     *
+     * @param $message
+     */
     public function __construct($message)
     {
         parent::__construct($message);

--- a/src/Exceptions/SignatureInvalidException.php
+++ b/src/Exceptions/SignatureInvalidException.php
@@ -6,6 +6,11 @@ use Exception;
 
 class SignatureInvalidException extends Exception
 {
+    /**
+     * SignatureInvalidException constructor.
+     *
+     * @param $message
+     */
     public function __construct($message)
     {
         parent::__construct($message);

--- a/src/Exceptions/UnexpectedValueException.php
+++ b/src/Exceptions/UnexpectedValueException.php
@@ -6,6 +6,11 @@ use Exception;
 
 class UnexpectedValueException extends Exception
 {
+    /**
+     * UnexpectedValueException constructor.
+     *
+     * @param $message
+     */
     public function __construct($message)
     {
         parent::__construct($message);

--- a/src/Exceptions/ValueNotFoundException.php
+++ b/src/Exceptions/ValueNotFoundException.php
@@ -6,6 +6,11 @@ use Exception;
 
 class ValueNotFoundException extends Exception
 {
+    /**
+     * ValueNotFoundException constructor.
+     *
+     * @param $message
+     */
     public function __construct($message)
     {
         parent::__construct($message);

--- a/src/JWTDecoder.php
+++ b/src/JWTDecoder.php
@@ -2,6 +2,7 @@
 
 namespace musa11971\JWTDecoder;
 
+use ArrayAccess;
 use DateTime;
 use DomainException;
 use musa11971\JWTDecoder\Exceptions\BeforeValidException;
@@ -20,17 +21,43 @@ class JWTDecoder
      * we want to provide some extra leeway time to
      * account for clock skew.
      */
-    public static $leeway = 0;
+    public static int $leeway = 0;
 
-    public $token;
-    public $keys = [];
-    private $options = [
+    /**
+     * The token that should be decoded.
+     *
+     * @var string $token
+     */
+    public string $token = '';
+    /**
+     * An array of the keys.
+     *
+     * @var array $keys
+     */
+    public array $keys = [];
+    /**
+     * Decoding options.
+     *
+     * @var array|false[]
+     */
+    private array $options = [
         'ignore_expiry' => false,
         'ignore_nbf'    => false
     ];
-    public $timestamp;
 
-    public static $supported_algs = array(
+    /**
+     * The timestamp used to validate the token.
+     *
+     * @var int|null $timestamp
+     */
+    public ?int $timestamp = null;
+
+    /**
+     * An array of the supported algorithms.
+     *
+     * @var array|\string[][]
+     */
+    public static array $supported_algs = array(
         'ES256' => array('openssl', 'SHA256'),
         'HS256' => array('hash_hmac', 'SHA256'),
         'HS384' => array('hash_hmac', 'SHA384'),
@@ -40,7 +67,12 @@ class JWTDecoder
         'RS512' => array('openssl', 'SHA512'),
     );
 
-    private function __construct($token)
+    /**
+     * JWTDecoder constructor.
+     *
+     * @param string $token The token that should be decoded.
+     */
+    private function __construct(string $token)
     {
         $this->token = $token;
     }
@@ -48,10 +80,11 @@ class JWTDecoder
     /**
      * Initializes the decoder with a token.
      *
-     * @param string $token
+     * @param string $token The token that should be decoded.
+     *
      * @return JWTDecoder
      */
-    public static function token($token)
+    public static function token(string $token): JWTDecoder
     {
         return new self($token);
     }
@@ -59,10 +92,11 @@ class JWTDecoder
     /**
      * Adds a key to use for decoding.
      *
-     * @param string $key
-     * @return $this
+     * @param string $key The key that should be used for decoding.
+     *
+     * @return JWTDecoder
      */
-    public function withKey($key)
+    public function withKey(string $key): JWTDecoder
     {
         $this->keys[] = $key;
         return $this;
@@ -71,13 +105,15 @@ class JWTDecoder
     /**
      * Adds multiple keys to use for decoding.
      *
-     * @param string[] $keys
-     * @return $this
+     * @param string[] $keys The keys that should be used for decoding.
+     *
+     * @return JWTDecoder
      */
-    public function withKeys($keys)
+    public function withKeys(array $keys): JWTDecoder
     {
-        foreach($keys as $key)
+        foreach ($keys as $key) {
             $this->withKey($key);
+        }
 
         return $this;
     }
@@ -85,10 +121,11 @@ class JWTDecoder
     /**
      * Sets whether to ignore the expiry on the JWT or not.
      *
-     * @param bool $ignore
-     * @return $this
+     * @param bool $ignore A boolean indicating whether to ignore expiry check.
+     *
+     * @return JWTDecoder
      */
-    public function ignoreExpiry($ignore = true)
+    public function ignoreExpiry(bool $ignore = true): JWTDecoder
     {
         $this->options['ignore_expiry'] = $ignore;
         return $this;
@@ -97,10 +134,11 @@ class JWTDecoder
     /**
      * Sets whether to ignore the 'not valid before' on the JWT or not.
      *
-     * @param bool $ignore
-     * @return $this
+     * @param bool $ignore A boolean indicating whether to ignore the 'not valid before' check.
+     *
+     * @return JWTDecoder
      */
-    public function ignoreNotValidBefore($ignore = true)
+    public function ignoreNotValidBefore(bool $ignore = true): JWTDecoder
     {
         $this->options['ignore_nbf'] = $ignore;
         return $this;
@@ -109,13 +147,17 @@ class JWTDecoder
     /**
      * Decodes the JWT with the key(s).
      *
-     * @return JWTPayload
-     * @throws null
+     * @return JWTPayload|null
+     *
+     * @throws \musa11971\JWTDecoder\Exceptions\BeforeValidException
+     * @throws \musa11971\JWTDecoder\Exceptions\ExpiredJWTException
+     * @throws \musa11971\JWTDecoder\Exceptions\InvalidArgumentException
+     * @throws \musa11971\JWTDecoder\Exceptions\SignatureInvalidException
+     * @throws \musa11971\JWTDecoder\Exceptions\UnexpectedValueException
      */
-    public function decode()
+    public function decode(): ?JWTPayload
     {
-        foreach($this->keys as $index => $key)
-        {
+        foreach ($this->keys as $index => $key) {
             try {
                 return $this->decodeWithKey($key);
             }
@@ -125,14 +167,14 @@ class JWTDecoder
                  * .. SignatureInvalidException, we will throw so the ..
                  * .. user can deal with it.
                  */
-                if($index == count($this->keys) - 1)
+                if ($index == count($this->keys) - 1) {
                     throw $e;
+                }
 
                 // Continue to next iteration, so that the next key can be attempted
                 continue;
             }
         }
-
         return null;
     }
 
@@ -140,10 +182,16 @@ class JWTDecoder
      * Attempt to decode the JWT with the given key.
      *
      * @param string $key
+     *
      * @return JWTPayload
-     * @throws null
+     *
+     * @throws \musa11971\JWTDecoder\Exceptions\BeforeValidException
+     * @throws \musa11971\JWTDecoder\Exceptions\ExpiredJWTException
+     * @throws \musa11971\JWTDecoder\Exceptions\InvalidArgumentException
+     * @throws \musa11971\JWTDecoder\Exceptions\SignatureInvalidException
+     * @throws \musa11971\JWTDecoder\Exceptions\UnexpectedValueException
      */
-    private function decodeWithKey($key)
+    private function decodeWithKey(string $key): JWTPayload
     {
         $jwt = $this->token;
 
@@ -156,7 +204,7 @@ class JWTDecoder
         if (count($tks) != 3) {
             throw new UnexpectedValueException('Wrong number of segments');
         }
-        list($headb64, $bodyb64, $cryptob64) = $tks;
+        [$headb64, $bodyb64, $cryptob64] = $tks;
         if (null === ($header = static::jsonDecode(static::urlsafeB64Decode($headb64)))) {
             throw new UnexpectedValueException('Invalid header encoding');
         }
@@ -177,7 +225,7 @@ class JWTDecoder
             $sig = self::signatureToDER($sig);
         }
 
-        if (is_array($key) || $key instanceof \ArrayAccess) {
+        if (is_array($key) || $key instanceof ArrayAccess) {
             if (isset($header->kid)) {
                 if (!isset($key[$header->kid])) {
                     throw new UnexpectedValueException('"kid" invalid, unable to lookup correct key');
@@ -195,7 +243,7 @@ class JWTDecoder
 
         // Check the nbf if it is defined. This is the time that the
         // token can actually be used. If it's not yet that time, abort.
-        if(!$this->options['ignore_nbf']) {
+        if (!$this->options['ignore_nbf']) {
             if (isset($payload->nbf) && $payload->nbf > ($timestamp + static::$leeway)) {
                 throw new BeforeValidException(
                     'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->nbf)
@@ -206,7 +254,7 @@ class JWTDecoder
         // Check that this token has been created before 'now'. This prevents
         // using tokens that have been created for later use (and haven't
         // correctly used the nbf claim).
-        if(!$this->options['ignore_nbf']) {
+        if (!$this->options['ignore_nbf']) {
             if (isset($payload->iat) && $payload->iat > ($timestamp + static::$leeway)) {
                 throw new BeforeValidException(
                     'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->iat)
@@ -215,7 +263,7 @@ class JWTDecoder
         }
 
         // Check if this token has expired.
-        if(!$this->options['ignore_expiry']) {
+        if (!$this->options['ignore_expiry']) {
             if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
                 throw new ExpiredJWTException('Expired token');
             }
@@ -228,60 +276,60 @@ class JWTDecoder
      * Verify a signature with the message, key and method. Not all methods
      * are symmetric, so we must have a separate verify and sign method.
      *
-     * @param string            $msg        The original message (header and body)
-     * @param string            $signature  The original signature
-     * @param string|resource   $key        For HS*, a string key works. for RS*, must be a resource of an openssl public key
-     * @param string            $alg        The algorithm
+     * @param string          $msg       The original message (header and body)
+     * @param string          $signature The original signature
+     * @param string|resource $key       For HS*, a string key works. for RS*, must be a resource of an openssl public key
+     * @param string          $alg       The algorithm
      *
      * @return bool
      *
-     * @throws DomainException Invalid Algorithm or OpenSSL failure
+     * @throws \DomainException Invalid Algorithm or OpenSSL failure
      */
-    private static function verify($msg, $signature, $key, $alg)
+    private static function verify(string $msg, string $signature, $key, string $alg): bool
     {
         if (empty(static::$supported_algs[$alg])) {
             throw new DomainException('Algorithm not supported');
         }
 
-        list($function, $algorithm) = static::$supported_algs[$alg];
+        [$function, $algorithm] = static::$supported_algs[$alg];
         switch ($function) {
-            case 'openssl':
-                $success = openssl_verify($msg, $signature, $key, $algorithm);
-                if ($success === 1) {
-                    return true;
-                } elseif ($success === 0) {
-                    return false;
-                }
-                // returns 1 on success, 0 on failure, -1 on error.
-                throw new DomainException(
-                    'OpenSSL error: ' . openssl_error_string()
-                );
-            case 'hash_hmac':
-            default:
-                $hash = hash_hmac($algorithm, $msg, $key, true);
-                if (function_exists('hash_equals')) {
-                    return hash_equals($signature, $hash);
-                }
-                $len = min(static::safeStrlen($signature), static::safeStrlen($hash));
+        case 'openssl':
+            $success = openssl_verify($msg, $signature, $key, $algorithm);
+            if ($success === 1) {
+                return true;
+            } elseif ($success === 0) {
+                return false;
+            }
+            // returns 1 on success, 0 on failure, -1 on error.
+            throw new DomainException(
+                'OpenSSL error: ' . openssl_error_string()
+            );
+        case 'hash_hmac':
+        default:
+            $hash = hash_hmac($algorithm, $msg, $key, true);
+            if (function_exists('hash_equals')) {
+                return hash_equals($signature, $hash);
+            }
+            $len = min(static::safeStrlen($signature), static::safeStrlen($hash));
 
-                $status = 0;
-                for ($i = 0; $i < $len; $i++) {
-                    $status |= (ord($signature[$i]) ^ ord($hash[$i]));
-                }
-                $status |= (static::safeStrlen($signature) ^ static::safeStrlen($hash));
+            $status = 0;
+            for ($i = 0; $i < $len; $i++) {
+                $status |= (ord($signature[$i]) ^ ord($hash[$i]));
+            }
+            $status |= (static::safeStrlen($signature) ^ static::safeStrlen($hash));
 
-                return ($status === 0);
+            return ($status === 0);
         }
     }
 
     /**
      * Get the number of bytes in cryptographic strings.
      *
-     * @param string $str
+     * @param string $str The string used to determine the number of bytes.
      *
      * @return int
      */
-    private static function safeStrlen($str)
+    private static function safeStrlen(string $str): int
     {
         if (function_exists('mb_strlen')) {
             return mb_strlen($str, '8bit');
@@ -296,21 +344,19 @@ class JWTDecoder
      *
      * @return object Object representation of JSON string
      *
-     * @throws DomainException Provided string was invalid JSON
+     * @throws \DomainException Provided string was invalid JSON
      */
-    public static function jsonDecode($input)
+    public static function jsonDecode(string $input): object
     {
         if (version_compare(PHP_VERSION, '5.4.0', '>=') && !(defined('JSON_C_VERSION') && PHP_INT_SIZE > 4)) {
-            /** In PHP >=5.4.0, json_decode() accepts an options parameter, that allows you
-             * to specify that large ints (like Steam Transaction IDs) should be treated as
-             * strings, rather than the PHP default behaviour of converting them to floats.
-             */
+            // In PHP >=5.4.0, json_decode() accepts an options parameter, that allows you
+            // to specify that large ints (like Steam Transaction IDs) should be treated as
+            // strings, rather than the PHP default behaviour of converting them to floats.
             $obj = json_decode($input, false, 512, JSON_BIGINT_AS_STRING);
         } else {
-            /** Not all servers will support that, however, so for older versions we must
-             * manually detect large ints in the JSON string and quote them (thus converting
-             *them to strings) before decoding, hence the preg_replace() call.
-             */
+            // Not all servers will support that, however, so for older versions we must
+            // manually detect large ints in the JSON string and quote them (thus converting
+            // them to strings) before decoding, hence the preg_replace() call.
             $max_int_length = strlen((string) PHP_INT_MAX) - 1;
             $json_without_bigints = preg_replace('/:\s*(-?\d{'.$max_int_length.',})/', ': "$1"', $input);
             $obj = json_decode($json_without_bigints);
@@ -331,7 +377,7 @@ class JWTDecoder
      *
      * @return string A decoded string
      */
-    public static function urlsafeB64Decode($input)
+    public static function urlsafeB64Decode(string $input): string
     {
         $remainder = strlen($input) % 4;
         if ($remainder) {
@@ -344,13 +390,14 @@ class JWTDecoder
     /**
      * Convert an ECDSA signature to an ASN.1 DER sequence
      *
-     * @param   string $sig The ECDSA signature to convert
-     * @return  string The encoded DER object
+     * @param string $sig The ECDSA signature to convert
+     *
+     * @return string The encoded DER object
      */
-    private static function signatureToDER($sig)
+    private static function signatureToDER(string $sig): string
     {
         // Separate the signature into r-value and s-value
-        list($r, $s) = str_split($sig, (int) (strlen($sig) / 2));
+        [$r, $s] = str_split($sig, (int) (strlen($sig) / 2));
 
         // Trim leading zeros
         $r = ltrim($r, "\x00");
@@ -375,11 +422,12 @@ class JWTDecoder
     /**
      * Encodes a value into a DER object.
      *
-     * @param   int     $type DER tag
-     * @param   string  $value the value to encode
-     * @return  string  the encoded object
+     * @param int    $type  DER tag
+     * @param string $value the value to encode
+     *
+     * @return string the encoded object
      */
-    private static function encodeDER($type, $value)
+    private static function encodeDER(int $type, string $value): string
     {
         $tag_header = 0;
         if ($type === self::ASN1_SEQUENCE) {
@@ -401,15 +449,18 @@ class JWTDecoder
      * @param int $errno An error number from json_last_error()
      *
      * @return void
+     *
+     * @throws \DomainException
      */
-    private static function handleJsonError($errno)
+    private static function handleJsonError(int $errno)
     {
         $messages = array(
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
             JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
             JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
             JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
-            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters' //PHP >= 5.3.3
+            //PHP >= 5.3.3
+            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters'
         );
         throw new DomainException(
             isset($messages[$errno])

--- a/src/JWTPayload.php
+++ b/src/JWTPayload.php
@@ -6,38 +6,50 @@ use musa11971\JWTDecoder\Exceptions\ValueNotFoundException;
 
 class JWTPayload
 {
-    /** @var Object $data */
-    private $data;
+    /**
+     * The payload data.
+     *
+     * @var object $_data
+     */
+    private object $_data;
 
-    public function __construct($data)
+    /**
+     * JWTPayload constructor.
+     *
+     * @param object $data The object used to create the payload.
+     */
+    public function __construct(object $data)
     {
-        $this->data = $data;
+        $this->_data = $data;
     }
 
     /**
      * Gets the value with the given key.
      *
-     * @param string $key
+     * @param string $key The key used to get a value from the payload.
+     *
      * @return mixed
-     * @throws null
+     * @throws \musa11971\JWTDecoder\Exceptions\ValueNotFoundException
      */
-    public function get($key)
+    public function get(string $key)
     {
-        if(!$this->has($key))
+        if (!$this->has($key)) {
             throw new ValueNotFoundException("Value with key `$key` not found in the JWT payload.");
+        }
 
-        return $this->data->$key;
+        return $this->_data->$key;
     }
 
     /**
      * Checks whether the payload has a value with the given key.
      *
-     * @param string $key
+     * @param string $key The key used to check whether the payload has a value.
+     *
      * @return bool
      */
-    public function has($key)
+    public function has(string $key): bool
     {
-        return isset($this->data->$key);
+        return isset($this->_data->$key);
     }
 
     /**
@@ -45,8 +57,8 @@ class JWTPayload
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
-        return (array) $this->data;
+        return (array) $this->_data;
     }
 }


### PR DESCRIPTION
Bumping release version to 2.0 is advised as this PR breaks compatibility with PHP 7.3.

- Updated compatibility to PHP 7.4 and PHP 8.0.
- Updated minimum PHP version to PHP 7.4.
- Updated codebase to address PHP 7.4 warnings
- Updated composer packages for PHP 7.4 requirement satisfaction
- Updated README.md